### PR TITLE
Adding quick payout request for Neteller clients

### DIFF
--- a/src/Request/PayoutRequest.php
+++ b/src/Request/PayoutRequest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Skrill\Request;
+
+use Money\Money;
+use Skrill\ValueObject\Email;
+use Skrill\ValueObject\Description;
+use Skrill\ValueObject\TransactionID;
+use Skrill\Request\Traits\GetPayloadTrait;
+use Skrill\Request\Traits\AmountFormatterTrait;
+
+/**
+ * Class PayoutRequest.
+ */
+final class PayoutRequest
+{
+    use GetPayloadTrait;
+    use AmountFormatterTrait;
+
+    /**
+     * @param Email       $recipientEmail
+     * @param Money       $amount
+     * @param Description $description
+     */
+    public function __construct(Money $amount, Description $description)
+    {
+        $this->payload = [
+            'currency' => strval($amount->getCurrency()),
+            'amount' => $this->formatToFloat($amount),
+            'subject' => $description->getSubject(),
+            'note' => $description->getText(),
+        ];
+    }
+
+    /**
+     * Your reference ID (must be unique if submitted).
+     *
+     * @param TransactionID $transactionId
+     *
+     * @return $this
+     */
+    public function setReferenceTransaction(TransactionID $transactionId): self
+    {
+        $this->payload['frn_trn_id'] = strval($transactionId);
+
+        return $this;
+    }
+
+    /**
+     * Set transaction_id of the original payment for quick checkout payouts
+     *
+     * @param TransactionID $transactionId instance
+     * @return $this
+     */
+    public function setOriginalTransactionId(TransactionId $transactionId): self
+    {
+        // documentation mentions either mb_transaction_id or transaction_id to be used.
+        $this->payload['transaction_id'] = strval($transactionId);
+
+        return $this;
+    }
+}

--- a/src/SkrillPayoutClientInterface.php
+++ b/src/SkrillPayoutClientInterface.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Skrill;
+
+use Skrill\ValueObject\Sid;
+use Skrill\Response\Response;
+use Skrill\Request\PayoutRequest;
+use Skrill\Exception\SkrillException;
+
+/**
+ * You can use the Automated Payments Interface to make automated partial or full refunds to customers,
+ * up to the amount of the original payment.
+ *
+ * @see https://www.skrill.com/fileadmin/content/pdf/Skrill_Automated_Payments_Interface_Guide.pdf
+ */
+interface SkrillPayoutClientInterface
+{
+    /**
+     * Preparing a quick payout.
+     *
+     * @param PayoutRequest $request
+     *
+     * @return Sid
+     *
+     * @throws SkrillException
+     */
+    public function preparePayout(PayoutRequest $request): Sid;
+
+    /**
+     * Executing a payout.
+     *
+     * @param Sid $sid
+     *
+     * @return Response
+     *
+     * @throws SkrillException
+     */
+    public function executePayout(Sid $sid): Response;
+}

--- a/tests/Request/PayoutRequestTest.php
+++ b/tests/Request/PayoutRequestTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Skrill\Tests\Request;
+
+use Skrill\ValueObject\Email;
+use PHPUnit\Framework\TestCase;
+use Money\Currencies\ISOCurrencies;
+use Skrill\ValueObject\Description;
+use Skrill\Request\PayoutRequest;
+use Money\Parser\DecimalMoneyParser;
+use Skrill\ValueObject\TransactionID;
+use Skrill\Exception\InvalidEmailException;
+use Skrill\Exception\InvalidDescriptionException;
+use Skrill\Exception\InvalidTransactionIDException;
+
+/**
+ * Class PayoutRequestTest.
+ */
+class PayoutRequestTest extends TestCase
+{
+    /**
+     * @throws InvalidDescriptionException
+     * @throws InvalidEmailException
+     * @throws InvalidTransactionIDException
+     */
+    public function testSuccess()
+    {
+        $parser = new DecimalMoneyParser(new ISOCurrencies());
+
+        $request = new PayoutRequest(
+            $parser->parse('1000000.51', 'EUR'),
+            new Description('Payout for Product ID:', '111')
+        );
+
+        self::assertEquals(
+            [
+                'currency' => 'EUR',
+                'amount' => 1000000.51,
+                'subject' => 'Payout for Product ID:',
+                'note' => '111',
+            ],
+            $request->getPayload()
+        );
+
+        self::assertInstanceOf(PayoutRequest::class, $request->setOriginalTransactionId(new TransactionID('test')));
+        self::assertInstanceOf(PayoutRequest::class, $request->setReferenceTransaction(new TransactionID('test-ref')));
+
+        self::assertEquals(
+            [
+                'currency' => 'EUR',
+                'amount' => 1000000.51,
+                'subject' => 'Payout for Product ID:',
+                'note' => '111',
+                'transaction_id' => 'test',
+                'frn_trn_id' => 'test-ref',
+            ],
+            $request->getPayload()
+        );
+    }
+}

--- a/tests/SkrillClientPreparePayoutTest.php
+++ b/tests/SkrillClientPreparePayoutTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Skrill\Tests;
+
+use Exception;
+use GuzzleHttp\Client;
+use Skrill\SkrillClient;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use Skrill\ValueObject\Email;
+use PHPUnit\Framework\TestCase;
+use GuzzleHttp\ClientInterface;
+use Skrill\ValueObject\Password;
+use Money\Currencies\ISOCurrencies;
+use Skrill\Request\PayoutRequest;
+use GuzzleHttp\Handler\MockHandler;
+use Skrill\ValueObject\Description;
+use Skrill\ValueObject\TransactionId;
+use Money\Parser\DecimalMoneyParser;
+use Psr\Http\Message\StreamInterface;
+use Skrill\Exception\SkrillException;
+use Psr\Http\Message\ResponseInterface;
+use GuzzleHttp\Exception\GuzzleException;
+use Skrill\Exception\InvalidEmailException;
+use PHPUnit\Framework\MockObject\MockObject;
+use Skrill\Exception\SkrillResponseException;
+use Skrill\Exception\InvalidPasswordException;
+use Skrill\Exception\InvalidDescriptionException;
+
+/**
+ * Class SkrillClientPreparePayoutTest.
+ */
+class SkrillClientPreparePayoutTest extends TestCase
+{
+    /**
+     * @var HandlerStack
+     */
+    private $successPayoutMockHandler;
+
+    /**
+     * @var HandlerStack
+     */
+    private $failPayoutMockHandler;
+
+    /**
+     * @var DecimalMoneyParser
+     */
+    private $parser;
+
+    /**
+     * @throws GuzzleException
+     * @throws InvalidDescriptionException
+     * @throws InvalidEmailException
+     * @throws InvalidPasswordException
+     * @throws SkrillException
+     * @throws Exception
+     */
+    public function testPreparePayoutSuccess()
+    {
+        $client = new Client(['handler' => $this->successPayoutMockHandler]);
+        $client = new SkrillClient($client, new Email('test@test.com'), new Password('q1234567'));
+
+        $request = new PayoutRequest(
+            $this->parser->parse('10', 'USD'),
+            new Description('subj', 'text')
+        );
+
+        $sid = $client->preparePayout($request);
+
+        self::assertEquals('5e281d1376d92ba789ca7f0583e045d4', (string) $sid);
+    }
+
+    /**
+     * @throws GuzzleException
+     * @throws InvalidDescriptionException
+     * @throws InvalidEmailException
+     * @throws InvalidPasswordException
+     * @throws SkrillException
+     */
+    public function testPreparePayoutFail()
+    {
+        self::expectException(SkrillResponseException::class);
+
+        $client = new Client(['handler' => $this->failPayoutMockHandler]);
+        $client = new SkrillClient($client, new Email('test@test.com'), new Password('q1234567'));
+
+        $request = new PayoutRequest(
+            $this->parser->parse('10', 'USD'),
+            new Description('subj', 'text')
+        );
+
+        $client->preparePayout($request);
+    }
+
+    /**
+     * @throws GuzzleException
+     * @throws InvalidDescriptionException
+     * @throws InvalidEmailException
+     * @throws InvalidPasswordException
+     * @throws SkrillException
+     */
+    public function testPreparePayoutCheckFormParams()
+    {
+        $email = 'test@test.com';
+        $transactionId = '12321';
+        $currency = 'EUR';
+        $amount = 10.55;
+        $password = 'q1234567';
+        $subject = 'Subject';
+        $note = 'Note';
+
+        /** @var ClientInterface|MockObject $client */
+        $client = self::createMock(ClientInterface::class);
+
+        $response = $this->createMock(ResponseInterface::class);
+        $responseBody = $this->createMock(StreamInterface::class);
+        $responseBody->expects(self::once())
+            ->method('getContents')
+            ->willReturn('<?xml version="1.0" encoding="UTF-8"?><response><sid>5e281d1376d92ba789ca7f0583e045d4</sid></response>');
+
+        $response->expects(self::once())
+            ->method('getBody')
+            ->willReturn($responseBody);
+
+        $client
+            ->expects(self::once())
+            ->method('request')
+            ->with('POST', 'https://www.skrill.com/app/pay.pl', [
+                'form_params' => [
+                    'action' => 'prepare',
+                    'transaction_id' => $transactionId,
+                    'currency' => $currency,
+                    'amount' => $amount,
+                    'subject' => $subject,
+                    'note' => $note,
+                    'email' => $email,
+                    'password' => md5($password),
+                ],
+                'headers' => [
+                    'Accept' => 'text/xml',
+                ],
+            ])
+            ->willReturn($response)
+        ;
+
+        $request = new PayoutRequest(
+            $this->parser->parse(strval($amount), $currency),
+            new Description($subject, $note)
+        );
+
+        $request->setOriginalTransactionId(new TransactionId($transactionId));
+
+        $client = new SkrillClient($client, new Email($email), new Password($password));
+
+        $client->preparePayout($request);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->parser = new DecimalMoneyParser(new ISOCurrencies());
+        $this->successPayoutMockHandler = HandlerStack::create(new MockHandler([
+            new Response(
+                200,
+                [],
+                '<?xml version="1.0" encoding="UTF-8"?><response><sid>5e281d1376d92ba789ca7f0583e045d4</sid></response>'
+            ),
+        ]));
+
+        $this->failPayoutMockHandler = HandlerStack::create(new MockHandler([
+            new Response(
+                200,
+                [],
+                '<?xml version="1.0" encoding="UTF-8"?><response><error><error_msg>MISSING_AMOUNT</error_msg></error></response>'
+            ),
+        ]));
+    }
+}


### PR DESCRIPTION
* Using only `beneficiary_email` field will cause Skrill withdrawals to skrill client accounts.
* Using `transaction_id` or `mb_transaction_id` initialises the payout to Neteller PSP, in case the client had at least one successful payin using Neteller under Skrill. This transaction id can be used in `transaction_id` field.

Reference to Section 5.0/5.1 in API Documentation of Skrill: https://www.skrill.com/fileadmin/content/pdf/Skrill_Automated_Payments_Interface_Guide.pdf