### PR TITLE
Fixing transaction id reference

### DIFF
--- a/src/Request/PayoutRequest.php
+++ b/src/Request/PayoutRequest.php
@@ -57,7 +57,7 @@ final class PayoutRequest
     public function setOriginalTransactionId(TransactionId $transactionId): self
     {
         // documentation mentions either mb_transaction_id or transaction_id to be used.
-        $this->payload['transaction_id'] = strval($transactionId);
+        $this->payload['mb_transaction_id'] = strval($transactionId);
 
         return $this;
     }

--- a/src/Request/PayoutRequest.php
+++ b/src/Request/PayoutRequest.php
@@ -54,9 +54,24 @@ final class PayoutRequest
      * @param TransactionID $transactionId instance
      * @return $this
      */
-    public function setOriginalTransactionId(TransactionId $transactionId): self
+    public function setOriginalTransactionId(TransactionID $transactionId): self
     {
-        // documentation mentions either mb_transaction_id or transaction_id to be used.
+        $this->payload['transaction_id'] = strval($transactionId);
+
+        return $this;
+    }
+
+    /**
+     * Setting The Skrill transaction ID of the original payment.
+     *
+     * Used for preparing Neteller payouts with initial neteller's successful deposit
+     * transaction ID.
+     *
+     * @param TransactionID $transactionId instance
+     * @return $this
+     */
+    public function setSkrillOriginalTransactionId(TransactionID $transactionId): self
+    {
         $this->payload['mb_transaction_id'] = strval($transactionId);
 
         return $this;

--- a/tests/Request/PayoutRequestTest.php
+++ b/tests/Request/PayoutRequestTest.php
@@ -44,7 +44,7 @@ class PayoutRequestTest extends TestCase
             $request->getPayload()
         );
 
-        self::assertInstanceOf(PayoutRequest::class, $request->setOriginalTransactionId(new TransactionID('test')));
+        self::assertInstanceOf(PayoutRequest::class, $request->setSkrillOriginalTransactionId(new TransactionID('test')));
         self::assertInstanceOf(PayoutRequest::class, $request->setReferenceTransaction(new TransactionID('test-ref')));
 
         self::assertEquals(

--- a/tests/Request/PayoutRequestTest.php
+++ b/tests/Request/PayoutRequestTest.php
@@ -53,7 +53,7 @@ class PayoutRequestTest extends TestCase
                 'amount' => 1000000.51,
                 'subject' => 'Payout for Product ID:',
                 'note' => '111',
-                'transaction_id' => 'test',
+                'mb_transaction_id' => 'test',
                 'frn_trn_id' => 'test-ref',
             ],
             $request->getPayload()

--- a/tests/SkrillClientPreparePayoutTest.php
+++ b/tests/SkrillClientPreparePayoutTest.php
@@ -130,7 +130,7 @@ class SkrillClientPreparePayoutTest extends TestCase
             ->with('POST', 'https://www.skrill.com/app/pay.pl', [
                 'form_params' => [
                     'action' => 'prepare',
-                    'transaction_id' => $transactionId,
+                    'mb_transaction_id' => $transactionId,
                     'currency' => $currency,
                     'amount' => $amount,
                     'subject' => $subject,

--- a/tests/SkrillClientPreparePayoutTest.php
+++ b/tests/SkrillClientPreparePayoutTest.php
@@ -150,7 +150,7 @@ class SkrillClientPreparePayoutTest extends TestCase
             new Description($subject, $note)
         );
 
-        $request->setOriginalTransactionId(new TransactionId($transactionId));
+        $request->setSkrillOriginalTransactionId(new TransactionId($transactionId));
 
         $client = new SkrillClient($client, new Email($email), new Password($password));
 


### PR DESCRIPTION
Fixed the field name after troubleshooting the issue with Paysafe tech support. 

Apparently, `mb_transaction_id` should be the one carrying the reference to initial Neteller deposit in order to make a withdrawal to Neteller's client account.

UPD: @zhooravell , if there's a chance of reviewing and merge & tag it, it would be super great, so we could patch the app with the up-to-date fix :)