### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ php:
 
 before_script:
   - travis_retry composer self-update
-  - travis_retry composer install --no-interaction --prefer-source --dev
+  - travis_retry composer install --no-interaction --prefer-source
 
 script:
   - vendor/bin/phpunit --coverage-clover=coverage.xml

--- a/tests/Factory/ResponseFactoryFromRefundTest.php
+++ b/tests/Factory/ResponseFactoryFromRefundTest.php
@@ -39,7 +39,7 @@ class ResponseFactoryFromRefundTest extends TestCase
         self::assertEquals('USD', $response->get('mb_currency'));
         self::assertEquals('e40a8e22-016e-4687-870c-f073631e3131', $response->get('transaction_id'));
         self::assertEquals(2, $response->get('status'));
-        self::assertEquals(null, $response->get('error'));
+        self::assertNull($response->get('error'));
     }
 
     /**

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -13,8 +13,8 @@ class HelpersTest extends TestCase
 {
     public function testResourcesFilesExists()
     {
-        self::assertTrue(file_exists(__DIR__ . '/../resources/iso-3166-1-alpha-3-countries-skill-supports.php'));
-        self::assertTrue(file_exists(__DIR__ . '/../resources/iso-6391-languages-skrill-supports.php'));
+        self::assertFileExists(__DIR__ . '/../resources/iso-3166-1-alpha-3-countries-skill-supports.php');
+        self::assertFileExists(__DIR__ . '/../resources/iso-6391-languages-skrill-supports.php');
     }
 
     public function testGetSkillSupportsCountries()
@@ -23,10 +23,12 @@ class HelpersTest extends TestCase
 
         $countries = getSkillSupportsCountries();
 
-        self::assertTrue(is_array($countries));
+        self::assertIsArray($countries);
         self::assertCount(238, $countries);
 
-        foreach ($countries as $country => $title) {
+        $countryLists = array_keys($countries);
+
+        foreach ($countryLists as $country) {
             self::assertEquals(3, mb_strlen($country));
         }
 
@@ -49,10 +51,12 @@ class HelpersTest extends TestCase
 
         $languages = getSkillSupportsLanguages();
 
-        self::assertTrue(is_array($languages));
+        self::assertIsArray($languages);
         self::assertCount(18, $languages);
 
-        foreach ($languages as $language => $title) {
+        $languageLists = array_keys($languages);
+
+        foreach ($languageLists as $language) {
             self::assertEquals(2, mb_strlen($language));
         }
     }

--- a/tests/Response/ResponseTest.php
+++ b/tests/Response/ResponseTest.php
@@ -22,7 +22,7 @@ class ResponseTest extends TestCase
     {
         $method = new ReflectionClass(Response::class);
 
-        $this->assertTrue($method->isFinal());
+        self::assertTrue($method->isFinal());
     }
 
     /**
@@ -35,7 +35,7 @@ class ResponseTest extends TestCase
      */
     public function testDotNotation($key, $expected, array $data, $default = null)
     {
-        $this->assertEquals($expected, (new Response($data))->get($key, $default));
+        self::assertEquals($expected, (new Response($data))->get($key, $default));
     }
 
     /**
@@ -154,8 +154,8 @@ class ResponseTest extends TestCase
     {
         $response = new Response(['userId' => 111]);
 
-        $this->assertTrue(isset($response->userId));
-        $this->assertFalse(isset($response->address));
+        self::assertTrue(isset($response->userId));
+        self::assertFalse(isset($response->address));
     }
 
     public function testGetPropertyValue()
@@ -163,7 +163,7 @@ class ResponseTest extends TestCase
         $userId = 111;
         $response = new Response(['userId' => $userId]);
 
-        $this->assertEquals($userId, $response->userId);
+        self::assertEquals($userId, $response->userId);
     }
 
     public function testGetNotExistsPropertyValue()
@@ -171,7 +171,7 @@ class ResponseTest extends TestCase
         $userId = 111;
         $response = new Response(['userId' => $userId]);
 
-        $this->assertNull($response->address);
+        self::assertNull($response->address);
     }
 
     public function testGetValuesMixedApproach()
@@ -185,10 +185,10 @@ class ResponseTest extends TestCase
             ],
         ]);
 
-        $this->assertNull($response->get('address.street_2'));
-        $this->assertEquals($street, $response->get('address.street'));
-        $this->assertEquals($userId, $response->userId);
-        $this->assertEquals($userId, $response->get('userId'));
-        $this->assertEquals(['street' => $street], $response->address);
+        self::assertNull($response->get('address.street_2'));
+        self::assertEquals($street, $response->get('address.street'));
+        self::assertEquals($userId, $response->userId);
+        self::assertEquals($userId, $response->get('userId'));
+        self::assertEquals(['street' => $street], $response->address);
     }
 }

--- a/tests/SkrillClientExecuteOnDemandTest.php
+++ b/tests/SkrillClientExecuteOnDemandTest.php
@@ -72,7 +72,7 @@ class SkrillClientExecuteOnDemandTest extends TestCase
      */
     public function testExecuteOnDemandFail()
     {
-        self::expectException(SkrillResponseException::class);
+        $this->expectException(SkrillResponseException::class);
 
         $client = new Client(['handler' => $this->failOnDemandMockHandler]);
         $client = new SkrillClient($client, new Email('test@test.com'), new Password('q1234567'));
@@ -94,7 +94,7 @@ class SkrillClientExecuteOnDemandTest extends TestCase
         $sid = 'sid';
 
         /** @var ClientInterface|MockObject $client */
-        $client = self::createMock(ClientInterface::class);
+        $client = $this->createMock(ClientInterface::class);
 
         $response = $this->createMock(ResponseInterface::class);
         $responseBody = $this->createMock(StreamInterface::class);

--- a/tests/SkrillClientExecutePayoutTest.php
+++ b/tests/SkrillClientExecutePayoutTest.php
@@ -82,7 +82,7 @@ class SkrillClientExecutePayoutTest extends TestCase
      */
     public function testExecutePayoutFail()
     {
-        self::expectException(SkrillResponseException::class);
+        $this->expectException(SkrillResponseException::class);
 
         $client = new Client(['handler' => $this->failPayoutMockHandler]);
         $client = new SkrillClient($client, new Email('test@test.com'), new Password('q1234567'));

--- a/tests/SkrillClientExecuteRefundTest.php
+++ b/tests/SkrillClientExecuteRefundTest.php
@@ -71,7 +71,7 @@ class SkrillClientExecuteRefundTest extends TestCase
      */
     public function testExecuteRefundFail()
     {
-        self::expectException(SkrillResponseException::class);
+        $this->expectException(SkrillResponseException::class);
 
         $client = new Client(['handler' => $this->failRefundMockHandler]);
         $client = new SkrillClient($client, new Email('test@test.com'), new Password('q1234567'));
@@ -93,7 +93,7 @@ class SkrillClientExecuteRefundTest extends TestCase
         $sid = 'sid';
 
         /** @var ClientInterface $client */
-        $client = self::createMock(ClientInterface::class);
+        $client = $this->createMock(ClientInterface::class);
 
         $response = $this->createMock(ResponseInterface::class);
         $responseBody = $this->createMock(StreamInterface::class);

--- a/tests/SkrillClientExecuteTransferTest.php
+++ b/tests/SkrillClientExecuteTransferTest.php
@@ -71,7 +71,7 @@ class SkrillClientExecuteTransferTest extends TestCase
      */
     public function testExecuteTransferFail()
     {
-        self::expectException(SkrillResponseException::class);
+        $this->expectException(SkrillResponseException::class);
 
         $client = new Client(['handler' => $this->failTransferMockHandler]);
         $client = new SkrillClient($client, new Email('test@test.com'), new Password('q1234567'));
@@ -93,7 +93,7 @@ class SkrillClientExecuteTransferTest extends TestCase
         $sid = 'sid';
 
         /** @var ClientInterface $client */
-        $client = self::createMock(ClientInterface::class);
+        $client = $this->createMock(ClientInterface::class);
 
         $response = $this->createMock(ResponseInterface::class);
         $responseBody = $this->createMock(StreamInterface::class);
@@ -163,7 +163,7 @@ XML;
     </transaction>
 </response>
 XML;
-        
+
         $this->successTransferMockHandler = HandlerStack::create(
             new MockHandler(
                 [

--- a/tests/SkrillClientPrepareOnDemandTest.php
+++ b/tests/SkrillClientPrepareOnDemandTest.php
@@ -85,7 +85,7 @@ class SkrillClientPrepareOnDemandTest extends TestCase
      */
     public function testPrepareOnDemandFail()
     {
-        self::expectException(SkrillResponseException::class);
+        $this->expectException(SkrillResponseException::class);
 
         $client = new Client(['handler' => $this->failOnDemandMockHandler]);
         $client = new SkrillClient($client, new Email('test@test.com'), new Password('q1234567'));
@@ -117,7 +117,7 @@ class SkrillClientPrepareOnDemandTest extends TestCase
         $transactionId = 222;
 
         /** @var ClientInterface|MockObject $client */
-        $client = self::createMock(ClientInterface::class);
+        $client = $this->createMock(ClientInterface::class);
 
         $response = $this->createMock(ResponseInterface::class);
         $responseBody = $this->createMock(StreamInterface::class);

--- a/tests/SkrillClientPreparePayoutTest.php
+++ b/tests/SkrillClientPreparePayoutTest.php
@@ -81,7 +81,7 @@ class SkrillClientPreparePayoutTest extends TestCase
      */
     public function testPreparePayoutFail()
     {
-        self::expectException(SkrillResponseException::class);
+        $this->expectException(SkrillResponseException::class);
 
         $client = new Client(['handler' => $this->failPayoutMockHandler]);
         $client = new SkrillClient($client, new Email('test@test.com'), new Password('q1234567'));
@@ -112,7 +112,7 @@ class SkrillClientPreparePayoutTest extends TestCase
         $note = 'Note';
 
         /** @var ClientInterface|MockObject $client */
-        $client = self::createMock(ClientInterface::class);
+        $client = $this->createMock(ClientInterface::class);
 
         $response = $this->createMock(ResponseInterface::class);
         $responseBody = $this->createMock(StreamInterface::class);

--- a/tests/SkrillClientPrepareRefundTest.php
+++ b/tests/SkrillClientPrepareRefundTest.php
@@ -75,7 +75,7 @@ class SkrillClientPrepareRefundTest extends TestCase
      */
     public function testPrepareTransferFail()
     {
-        self::expectException(SkrillResponseException::class);
+        $this->expectException(SkrillResponseException::class);
 
         $client = new Client(['handler' => $this->failRefundMockHandler]);
         $client = new SkrillClient($client, new Email('test@test.com'), new Password('q1234567'));
@@ -97,7 +97,7 @@ class SkrillClientPrepareRefundTest extends TestCase
         $password = 'q1234567';
 
         /** @var ClientInterface|MockObject $client */
-        $client = self::createMock(ClientInterface::class);
+        $client = $this->createMock(ClientInterface::class);
 
         $response = $this->createMock(ResponseInterface::class);
         $responseBody = $this->createMock(StreamInterface::class);

--- a/tests/SkrillClientPrepareSaleTest.php
+++ b/tests/SkrillClientPrepareSaleTest.php
@@ -118,7 +118,7 @@ class SkrillClientPrepareSaleTest extends TestCase
      */
     public function testPrepareSaleFail()
     {
-        self::expectException(SkrillResponseException::class);
+        $this->expectException(SkrillResponseException::class);
 
         $client = new Client(['handler' => $this->failSaleMockHandler]);
         $client = new SkrillClient($client, new Email('test@test.com'), new Password('q1234567'));
@@ -145,7 +145,7 @@ class SkrillClientPrepareSaleTest extends TestCase
         $transactionId = new TransactionID('123');
 
         /** @var ClientInterface|MockObject $client */
-        $client = self::createMock(ClientInterface::class);
+        $client = $this->createMock(ClientInterface::class);
 
         $response = $this->createMock(ResponseInterface::class);
         $responseBody = $this->createMock(StreamInterface::class);
@@ -209,7 +209,7 @@ class SkrillClientPrepareSaleTest extends TestCase
         $transactionId = new TransactionID('123');
 
         /** @var ClientInterface|MockObject $client */
-        $client = self::createMock(ClientInterface::class);
+        $client = $this->createMock(ClientInterface::class);
 
         $response = $this->createMock(ResponseInterface::class);
         $responseBody = $this->createMock(StreamInterface::class);

--- a/tests/SkrillClientPrepareTransferTest.php
+++ b/tests/SkrillClientPrepareTransferTest.php
@@ -81,7 +81,7 @@ class SkrillClientPrepareTransferTest extends TestCase
      */
     public function testPrepareTransferFail()
     {
-        self::expectException(SkrillResponseException::class);
+        $this->expectException(SkrillResponseException::class);
 
         $client = new Client(['handler' => $this->failTransferMockHandler]);
         $client = new SkrillClient($client, new Email('test@test.com'), new Password('q1234567'));
@@ -113,7 +113,7 @@ class SkrillClientPrepareTransferTest extends TestCase
         $note = 'Note';
 
         /** @var ClientInterface|MockObject $client */
-        $client = self::createMock(ClientInterface::class);
+        $client = $this->createMock(ClientInterface::class);
 
         $response = $this->createMock(ResponseInterface::class);
         $responseBody = $this->createMock(StreamInterface::class);

--- a/tests/SkrillClientViewHistoryTest.php
+++ b/tests/SkrillClientViewHistoryTest.php
@@ -83,7 +83,7 @@ class SkrillClientViewHistoryTest extends TestCase
      */
     public function testViewHistoryFail()
     {
-        self::expectException(SkrillResponseException::class);
+        $this->expectException(SkrillResponseException::class);
         $this->expectExceptionMessage('Skrill error: Illegal parameter value: 02-08-201');
 
         $client = new Client(['handler' => $this->failHistoryMockHandler]);
@@ -100,7 +100,7 @@ class SkrillClientViewHistoryTest extends TestCase
      */
     public function testViewHistoryInvalidTime()
     {
-        self::expectException(SkrillResponseException::class);
+        $this->expectException(SkrillResponseException::class);
         $this->expectExceptionMessage('Skrill error: Invalid time "TEST".');
 
         $client = new Client(['handler' => $this->invalidTimeHistoryMockHandler]);

--- a/tests/ValueObject/CompanyNameTest.php
+++ b/tests/ValueObject/CompanyNameTest.php
@@ -50,8 +50,8 @@ class CompanyNameTest extends TestCase
      */
     public function testInvalidMaxLength()
     {
-        self::expectException(InvalidCompanyNameException::class);
-        self::expectExceptionMessage('The length of company name should not exceed 30 characters.');
+        $this->expectException(InvalidCompanyNameException::class);
+        $this->expectExceptionMessage('The length of company name should not exceed 30 characters.');
 
         new CompanyName(str_repeat('a', 35));
     }

--- a/tests/ValueObject/DescriptionTest.php
+++ b/tests/ValueObject/DescriptionTest.php
@@ -34,8 +34,8 @@ class DescriptionTest extends StringValueObjectTestCase
      */
     public function testEmptyText(string $value)
     {
-        self::expectException(InvalidDescriptionException::class);
-        self::expectExceptionMessage('Description text should not be blank.');
+        $this->expectException(InvalidDescriptionException::class);
+        $this->expectExceptionMessage('Description text should not be blank.');
 
         new Description('Product ID:', $value);
     }
@@ -49,8 +49,8 @@ class DescriptionTest extends StringValueObjectTestCase
      */
     public function testEmptyDescription(string $value)
     {
-        self::expectException(InvalidDescriptionException::class);
-        self::expectExceptionMessage('Description subject should not be blank.');
+        $this->expectException(InvalidDescriptionException::class);
+        $this->expectExceptionMessage('Description subject should not be blank.');
 
         new Description($value, '4509334');
     }

--- a/tests/ValueObject/EmailTest.php
+++ b/tests/ValueObject/EmailTest.php
@@ -36,8 +36,8 @@ class EmailTest extends TestCase
      */
     public function testInvalidValue()
     {
-        self::expectException(InvalidEmailException::class);
-        self::expectExceptionMessage('Email is not a valid email address.');
+        $this->expectException(InvalidEmailException::class);
+        $this->expectExceptionMessage('Email is not a valid email address.');
 
         new Email('test');
     }

--- a/tests/ValueObject/LanguageTest.php
+++ b/tests/ValueObject/LanguageTest.php
@@ -49,8 +49,8 @@ class LanguageTest extends TestCase
      */
     public function testInvalidValue()
     {
-        self::expectException(InvalidLangException::class);
-        self::expectExceptionMessage('Not accepted language by Skrill.');
+        $this->expectException(InvalidLangException::class);
+        $this->expectExceptionMessage('Not accepted language by Skrill.');
 
         new Language('test');
     }

--- a/tests/ValueObject/PasswordTest.php
+++ b/tests/ValueObject/PasswordTest.php
@@ -35,8 +35,8 @@ class PasswordTest extends StringValueObjectTestCase
      */
     public function testInvalidMinLength()
     {
-        self::expectException(InvalidPasswordException::class);
-        self::expectExceptionMessage('Skrill API/MQI password is too short. It should have 8 characters or more.');
+        $this->expectException(InvalidPasswordException::class);
+        $this->expectExceptionMessage('Skrill API/MQI password is too short. It should have 8 characters or more.');
 
         new Password('a123');
     }
@@ -50,8 +50,8 @@ class PasswordTest extends StringValueObjectTestCase
      */
     public function testEmpty(string $value)
     {
-        self::expectException(InvalidPasswordException::class);
-        self::expectExceptionMessage('Skrill API/MQI password is too short. It should have 8 characters or more.');
+        $this->expectException(InvalidPasswordException::class);
+        $this->expectExceptionMessage('Skrill API/MQI password is too short. It should have 8 characters or more.');
 
         new Password($value);
     }
@@ -61,8 +61,8 @@ class PasswordTest extends StringValueObjectTestCase
      */
     public function testMissingLetters()
     {
-        self::expectException(InvalidPasswordException::class);
-        self::expectExceptionMessage('Skrill API/MQI password must include at least one letter.');
+        $this->expectException(InvalidPasswordException::class);
+        $this->expectExceptionMessage('Skrill API/MQI password must include at least one letter.');
 
         new Password('12345678');
     }
@@ -72,8 +72,8 @@ class PasswordTest extends StringValueObjectTestCase
      */
     public function testMissingNumbers()
     {
-        self::expectException(InvalidPasswordException::class);
-        self::expectExceptionMessage('Skrill API/MQI password must include at least one number.');
+        $this->expectException(InvalidPasswordException::class);
+        $this->expectExceptionMessage('Skrill API/MQI password must include at least one number.');
 
         new Password('qwertyui');
     }

--- a/tests/ValueObject/RecurringBillingNoteTest.php
+++ b/tests/ValueObject/RecurringBillingNoteTest.php
@@ -39,8 +39,8 @@ class RecurringBillingNoteTest extends StringValueObjectTestCase
      */
     public function testEmptyValue(string $value)
     {
-        self::expectException(InvalidRecurringBillingNoteException::class);
-        self::expectExceptionMessage('Skrill recurring billing note should not be blank.');
+        $this->expectException(InvalidRecurringBillingNoteException::class);
+        $this->expectExceptionMessage('Skrill recurring billing note should not be blank.');
 
         new RecurringBillingNote($value);
     }

--- a/tests/ValueObject/RecurringPaymentIdTest.php
+++ b/tests/ValueObject/RecurringPaymentIdTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Skrill\Tests\ValueObject;
 
-use PHPUnit\Framework\TestCase;
 use Skrill\ValueObject\RecurringPaymentID;
 use Skrill\Exception\InvalidRecurringPaymentIDException;
 
@@ -40,8 +39,8 @@ class RecurringPaymentIdTest extends StringValueObjectTestCase
      */
     public function testEmptyValue(string $value)
     {
-        self::expectException(InvalidRecurringPaymentIDException::class);
-        self::expectExceptionMessage('Skrill recurring payment ID should not be blank.');
+        $this->expectException(InvalidRecurringPaymentIDException::class);
+        $this->expectExceptionMessage('Skrill recurring payment ID should not be blank.');
 
         new RecurringPaymentID($value);
     }

--- a/tests/ValueObject/SecretWordTest.php
+++ b/tests/ValueObject/SecretWordTest.php
@@ -36,8 +36,8 @@ class SecretWordTest extends StringValueObjectTestCase
      */
     public function testInvalidMaxLength()
     {
-        self::expectException(InvalidSecretWordException::class);
-        self::expectExceptionMessage('The length of Skrill secret word should not exceed 10 characters.');
+        $this->expectException(InvalidSecretWordException::class);
+        $this->expectExceptionMessage('The length of Skrill secret word should not exceed 10 characters.');
 
         new SecretWord(str_repeat('a', 35));
     }
@@ -51,8 +51,8 @@ class SecretWordTest extends StringValueObjectTestCase
      */
     public function testEmptyValue(string $value)
     {
-        self::expectException(InvalidSecretWordException::class);
-        self::expectExceptionMessage('Skrill secret word should not be blank.');
+        $this->expectException(InvalidSecretWordException::class);
+        $this->expectExceptionMessage('Skrill secret word should not be blank.');
 
         new SecretWord($value);
     }
@@ -66,8 +66,8 @@ class SecretWordTest extends StringValueObjectTestCase
      */
     public function testSpecialCharacters($value)
     {
-        self::expectException(InvalidSecretWordException::class);
-        self::expectExceptionMessage('Special characters are not permitted in Skrill secret word.');
+        $this->expectException(InvalidSecretWordException::class);
+        $this->expectExceptionMessage('Special characters are not permitted in Skrill secret word.');
 
         new SecretWord($value);
     }

--- a/tests/ValueObject/SidTest.php
+++ b/tests/ValueObject/SidTest.php
@@ -35,8 +35,8 @@ class SidTest extends StringValueObjectTestCase
      */
     public function testEmptyValue(string $value)
     {
-        self::expectException(InvalidSidException::class);
-        self::expectExceptionMessage('Skrill sid should not be blank.');
+        $this->expectException(InvalidSidException::class);
+        $this->expectExceptionMessage('Skrill sid should not be blank.');
 
         new Sid($value, new DateTimeImmutable());
     }

--- a/tests/ValueObject/SignatureTest.php
+++ b/tests/ValueObject/SignatureTest.php
@@ -34,8 +34,8 @@ class SignatureTest extends StringValueObjectTestCase
      */
     public function testEmptyValue(string $value)
     {
-        self::expectException(InvalidSignatureException::class);
-        self::expectExceptionMessage('Signature should not be blank.');
+        $this->expectException(InvalidSignatureException::class);
+        $this->expectExceptionMessage('Signature should not be blank.');
 
         new Signature($value);
     }
@@ -45,8 +45,8 @@ class SignatureTest extends StringValueObjectTestCase
      */
     public function testLowercase()
     {
-        self::expectException(InvalidSignatureException::class);
-        self::expectExceptionMessage('Signature should in uppercase.');
+        $this->expectException(InvalidSignatureException::class);
+        $this->expectExceptionMessage('Signature should in uppercase.');
 
         new Signature(md5('test123'));
     }

--- a/tests/ValueObject/TransactionIDTest.php
+++ b/tests/ValueObject/TransactionIDTest.php
@@ -39,8 +39,8 @@ class TransactionIDTest extends StringValueObjectTestCase
      */
     public function testEmptyValue(string $value)
     {
-        self::expectException(InvalidTransactionIDException::class);
-        self::expectExceptionMessage('Skrill transaction ID should not be blank.');
+        $this->expectException(InvalidTransactionIDException::class);
+        $this->expectExceptionMessage('Skrill transaction ID should not be blank.');
 
         new TransactionID($value);
     }

--- a/tests/ValueObject/UrlTest.php
+++ b/tests/ValueObject/UrlTest.php
@@ -21,8 +21,8 @@ class UrlTest extends StringValueObjectTestCase
      */
     public function testEmpty(string $value)
     {
-        self::expectException(InvalidUrlException::class);
-        self::expectExceptionMessage('"" is not a valid url.');
+        $this->expectException(InvalidUrlException::class);
+        $this->expectExceptionMessage('"" is not a valid url.');
 
         new Url($value);
     }
@@ -50,8 +50,8 @@ class UrlTest extends StringValueObjectTestCase
      */
     public function testInvalidUrl()
     {
-        self::expectException(InvalidUrlException::class);
-        self::expectExceptionMessage('"localhost" is not a valid url.');
+        $this->expectException(InvalidUrlException::class);
+        $this->expectExceptionMessage('"localhost" is not a valid url.');
 
         new Url('localhost');
     }


### PR DESCRIPTION
# Changed log
- PHPUnit has two ways to do assertion methods call.
One is using `$this` and another is `self::`.
And using the `$this` to do assertion calls are about `11` times.
And using the `self::` to do assertion calls are about `135` times.
To be consistency, it's nice to use all of assertion calls are `self::` call approach.

- Using the `$this->exception`, `$this->exceptionMessage` and `$this->createMock` method calls because it fixes the `Non static method 'expectException' should not be called`, `Non static method 'expectExceptionMessage' should not be called` and `Non static method 'createMock' should not be called` issues.
- Using the `assertNull` to assert expected value is `null`.
- Using the `assertFileExists` to assert expected file path is existed.
- Using the `assertIsArray` to assert expected value type is `array`.
- Removing `use PHPUnit\Framework\TestCase` namesapce on `tests/ValueObject/RecurringPaymentIdTest.php` file because this namespace is unused.