### PR TITLE
Improve PHPUnit fixtures and upgrade to PHPUnit ^8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "require-dev": {
         "infection/infection": "^0.15.3",
-        "phpunit/phpunit": "^7.0"
+        "phpunit/phpunit": "^8.0"
     },
     "autoload": {
         "files": [

--- a/tests/Factory/ResponseFactoryFromRefundTest.php
+++ b/tests/Factory/ResponseFactoryFromRefundTest.php
@@ -93,7 +93,7 @@ class ResponseFactoryFromRefundTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->response = $this->createMock(ResponseInterface::class);
         $this->responseBody = $this->createMock(StreamInterface::class);

--- a/tests/Factory/ResponseFactoryFromTransferTest.php
+++ b/tests/Factory/ResponseFactoryFromTransferTest.php
@@ -94,7 +94,7 @@ class ResponseFactoryFromTransferTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->response = $this->createMock(ResponseInterface::class);
         $this->responseBody = $this->createMock(StreamInterface::class);

--- a/tests/SkrillClientExecuteOnDemandTest.php
+++ b/tests/SkrillClientExecuteOnDemandTest.php
@@ -143,7 +143,7 @@ class SkrillClientExecuteOnDemandTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/SkrillClientExecutePayoutTest.php
+++ b/tests/SkrillClientExecutePayoutTest.php
@@ -93,7 +93,7 @@ class SkrillClientExecutePayoutTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/SkrillClientExecuteRefundTest.php
+++ b/tests/SkrillClientExecuteRefundTest.php
@@ -141,7 +141,7 @@ class SkrillClientExecuteRefundTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/SkrillClientExecuteTransferTest.php
+++ b/tests/SkrillClientExecuteTransferTest.php
@@ -145,7 +145,7 @@ XML;
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/SkrillClientPrepareOnDemandTest.php
+++ b/tests/SkrillClientPrepareOnDemandTest.php
@@ -167,7 +167,7 @@ class SkrillClientPrepareOnDemandTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/SkrillClientPreparePayoutTest.php
+++ b/tests/SkrillClientPreparePayoutTest.php
@@ -165,7 +165,7 @@ class SkrillClientPreparePayoutTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/SkrillClientPrepareRefundTest.php
+++ b/tests/SkrillClientPrepareRefundTest.php
@@ -138,7 +138,7 @@ class SkrillClientPrepareRefundTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/SkrillClientPrepareSaleTest.php
+++ b/tests/SkrillClientPrepareSaleTest.php
@@ -271,7 +271,7 @@ class SkrillClientPrepareSaleTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/SkrillClientPrepareTransferTest.php
+++ b/tests/SkrillClientPrepareTransferTest.php
@@ -165,7 +165,7 @@ class SkrillClientPrepareTransferTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/SkrillClientViewHistoryTest.php
+++ b/tests/SkrillClientViewHistoryTest.php
@@ -112,7 +112,7 @@ class SkrillClientViewHistoryTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
# Changed log
- Upgrading to PHPUnit `^8.` version since this library requires `php-7.2` version at least.
- According to [PHPUnit doc](https://phpunit.readthedocs.io/en/8.5/fixtures.html#more-setup-than-teardown), it should use `protected function setUp(): void`.