### PR TITLE
Improve assertions and fix test class namespace

### DIFF
--- a/tests/Factory/RedirectUrlFactoryTest.php
+++ b/tests/Factory/RedirectUrlFactoryTest.php
@@ -17,7 +17,7 @@ class RedirectUrlFactoryTest extends TestCase
      */
     public function testSuccess()
     {
-        self::assertEquals(
+        self::assertSame(
             'https://pay.skrill.com/?sid=6d7d0005655018a3ef7abd043ee31cfd',
             RedirectUrlFactory::fromSid(SidFactory::createFromString('6d7d0005655018a3ef7abd043ee31cfd'))
         );

--- a/tests/Factory/ResponseFactoryFromRefundTest.php
+++ b/tests/Factory/ResponseFactoryFromRefundTest.php
@@ -36,9 +36,9 @@ class ResponseFactoryFromRefundTest extends TestCase
         $response = ResponseFactory::createFromRefundResponse($this->response);
 
         self::assertEquals(1, $response->get('mb_amount'));
-        self::assertEquals('USD', $response->get('mb_currency'));
-        self::assertEquals('e40a8e22-016e-4687-870c-f073631e3131', $response->get('transaction_id'));
-        self::assertEquals(2, $response->get('status'));
+        self::assertSame('USD', $response->get('mb_currency'));
+        self::assertSame('e40a8e22-016e-4687-870c-f073631e3131', $response->get('transaction_id'));
+        self::assertSame('2', $response->get('status'));
         self::assertNull($response->get('error'));
     }
 
@@ -84,10 +84,10 @@ class ResponseFactoryFromRefundTest extends TestCase
         $response = ResponseFactory::createFromRefundResponse($this->response);
 
         self::assertEquals(1, $response->get('mb_amount'));
-        self::assertEquals('USD', $response->get('mb_currency'));
-        self::assertEquals('e40a8e22-016e-4687-870c-f073631e3131', $response->get('transaction_id'));
-        self::assertEquals(2, $response->get('status'));
-        self::assertEquals('ALREADY_REFUNDED', $response->get('error'));
+        self::assertSame('USD', $response->get('mb_currency'));
+        self::assertSame('e40a8e22-016e-4687-870c-f073631e3131', $response->get('transaction_id'));
+        self::assertSame('2', $response->get('status'));
+        self::assertSame('ALREADY_REFUNDED', $response->get('error'));
     }
 
     /**

--- a/tests/Factory/ResponseFactoryFromTransferTest.php
+++ b/tests/Factory/ResponseFactoryFromTransferTest.php
@@ -37,10 +37,10 @@ class ResponseFactoryFromTransferTest extends TestCase
         $response = ResponseFactory::createFromTransferResponse($this->response);
 
         self::assertEquals(0.50, $response->get('amount'));
-        self::assertEquals('USD', $response->get('currency'));
-        self::assertEquals(2451071245, $response->get('id'));
-        self::assertEquals(2, $response->get('status'));
-        self::assertEquals('processed', $response->get('status_msg'));
+        self::assertSame('USD', $response->get('currency'));
+        self::assertSame('2451071245', $response->get('id'));
+        self::assertSame('2', $response->get('status'));
+        self::assertSame('processed', $response->get('status_msg'));
     }
 
     /**
@@ -85,10 +85,10 @@ class ResponseFactoryFromTransferTest extends TestCase
         $response = ResponseFactory::createFromTransferResponse($this->response);
 
         self::assertEquals(0.50, $response->get('amount'));
-        self::assertEquals('USD', $response->get('currency'));
-        self::assertEquals(2451071245, $response->get('id'));
-        self::assertEquals(-2, $response->get('status'));
-        self::assertEquals('BALANCE_NOT_ENOUGH', $response->get('error_msg'));
+        self::assertSame('USD', $response->get('currency'));
+        self::assertSame('2451071245', $response->get('id'));
+        self::assertSame('-2', $response->get('status'));
+        self::assertSame('BALANCE_NOT_ENOUGH', $response->get('error_msg'));
     }
 
     /**

--- a/tests/Factory/SidFactoryTest.php
+++ b/tests/Factory/SidFactoryTest.php
@@ -20,16 +20,16 @@ class SidFactoryTest extends TestCase
         $rawSid = 'test';
         $sid = SidFactory::createFromString($rawSid);
 
-        self::assertEquals($rawSid, (string) $sid);
+        self::assertSame($rawSid, (string) $sid);
 
         $now = new \DateTime();
         $diff = $now->diff($sid->getExpirationTillDateTime());
 
         if (version_compare(PHP_VERSION, '7.2.0') >= 0) {
-            self::assertEquals(14, $diff->i);
-            self::assertEquals(59, $diff->s);
+            self::assertSame(14, $diff->i);
+            self::assertSame(59, $diff->s);
         } else {
-            self::assertEquals(15, $diff->i);
+            self::assertSame(15, $diff->i);
         }
     }
 }

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -29,7 +29,7 @@ class HelpersTest extends TestCase
         $countryLists = array_keys($countries);
 
         foreach ($countryLists as $country) {
-            self::assertEquals(3, mb_strlen($country));
+            self::assertSame(3, mb_strlen($country));
         }
 
         self::assertArrayNotHasKey('CUB', $countries);
@@ -57,7 +57,7 @@ class HelpersTest extends TestCase
         $languageLists = array_keys($languages);
 
         foreach ($languageLists as $language) {
-            self::assertEquals(2, mb_strlen($language));
+            self::assertSame(2, mb_strlen($language));
         }
     }
 }

--- a/tests/Response/HistoryItemTest.php
+++ b/tests/Response/HistoryItemTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Centrobill\Skrill\Tests\Response;
+namespace Skrill\Tests\Response;
 
 use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
@@ -47,17 +47,17 @@ class HistoryItemTest extends TestCase
         );
 
         self::assertEquals($time, $item->getTime());
-        self::assertEquals($type, $item->getType());
-        self::assertEquals($details, $item->getDetails());
-        self::assertEquals($lesion, $item->getLesion());
-        self::assertEquals($profit, $item->getProfit());
-        self::assertEquals($status, $item->getStatus());
-        self::assertEquals($balance, $item->getBalance());
-        self::assertEquals($reference, $item->getReference());
-        self::assertEquals($amount, $item->getAmount());
-        self::assertEquals($currency, $item->getCurrency());
-        self::assertEquals($info, $item->getInfo());
-        self::assertEquals($skrillId, $item->getSkrillId());
-        self::assertEquals($paymentType, $item->getPaymentType());
+        self::assertSame($type, $item->getType());
+        self::assertSame($details, $item->getDetails());
+        self::assertSame($lesion, $item->getLesion());
+        self::assertSame($profit, $item->getProfit());
+        self::assertSame($status, $item->getStatus());
+        self::assertSame($balance, $item->getBalance());
+        self::assertSame($reference, $item->getReference());
+        self::assertSame($amount, $item->getAmount());
+        self::assertSame($currency, $item->getCurrency());
+        self::assertSame($info, $item->getInfo());
+        self::assertSame($skrillId, $item->getSkrillId());
+        self::assertSame($paymentType, $item->getPaymentType());
     }
 }

--- a/tests/Response/ResponseTest.php
+++ b/tests/Response/ResponseTest.php
@@ -163,7 +163,7 @@ class ResponseTest extends TestCase
         $userId = 111;
         $response = new Response(['userId' => $userId]);
 
-        self::assertEquals($userId, $response->userId);
+        self::assertSame($userId, $response->userId);
     }
 
     public function testGetNotExistsPropertyValue()
@@ -186,9 +186,9 @@ class ResponseTest extends TestCase
         ]);
 
         self::assertNull($response->get('address.street_2'));
-        self::assertEquals($street, $response->get('address.street'));
-        self::assertEquals($userId, $response->userId);
-        self::assertEquals($userId, $response->get('userId'));
+        self::assertSame($street, $response->get('address.street'));
+        self::assertSame($userId, $response->userId);
+        self::assertSame($userId, $response->get('userId'));
         self::assertEquals(['street' => $street], $response->address);
     }
 }

--- a/tests/Signature/MD5SignatureCalculatorTest.php
+++ b/tests/Signature/MD5SignatureCalculatorTest.php
@@ -41,6 +41,6 @@ class MD5SignatureCalculatorTest extends TestCase
 
         $calculator = new MD5SignatureCalculator($secretWord, $merchantId, $formatter);
 
-        self::assertEquals($expected, (string) $calculator->calculate($transactionId, $amount, $status));
+        self::assertSame($expected, (string) $calculator->calculate($transactionId, $amount, $status));
     }
 }

--- a/tests/Signature/SHA2SignatureCalculatorTest.php
+++ b/tests/Signature/SHA2SignatureCalculatorTest.php
@@ -40,6 +40,6 @@ class SHA2SignatureCalculatorTest extends TestCase
 
         $calculator = new SHA2SignatureCalculator($secretWord, $merchantId, $formatter);
 
-        self::assertEquals($expected, (string) $calculator->calculate($transactionId, $amount, $status));
+        self::assertSame($expected, (string) $calculator->calculate($transactionId, $amount, $status));
     }
 }

--- a/tests/SkrillClientExecuteOnDemandTest.php
+++ b/tests/SkrillClientExecuteOnDemandTest.php
@@ -60,7 +60,7 @@ class SkrillClientExecuteOnDemandTest extends TestCase
 
         $result = $client->executeOnDemand(SidFactory::createFromString('test-sid'));
 
-        self::assertEquals('2451071245', $result->get('id'));
+        self::assertSame('2451071245', $result->get('id'));
     }
 
     /**

--- a/tests/SkrillClientExecutePayoutTest.php
+++ b/tests/SkrillClientExecutePayoutTest.php
@@ -63,14 +63,14 @@ class SkrillClientExecutePayoutTest extends TestCase
 
         $result = $client->executePayout(SidFactory::createFromString('test-sid'));
 
-        self::assertEquals('2451071245', $result->get('id'));
+        self::assertSame('2451071245', $result->get('id'));
         self::assertCount(1, $container); // should be one request
         /** @var Request $request */
         $request = $container[0]['request'];
         self::assertInstanceOf(Request::class, $request);
-        self::assertEquals('POST', $request->getMethod());
-        self::assertEquals('https://www.skrill.com/app/pay.pl', $request->getUri());
-        self::assertEquals('action=transfer&sid=test-sid', $request->getBody()->getContents());
+        self::assertSame('POST', $request->getMethod());
+        self::assertSame('https://www.skrill.com/app/pay.pl', (string)$request->getUri());
+        self::assertSame('action=transfer&sid=test-sid', $request->getBody()->getContents());
     }
 
     /**

--- a/tests/SkrillClientExecuteRefundTest.php
+++ b/tests/SkrillClientExecuteRefundTest.php
@@ -59,7 +59,7 @@ class SkrillClientExecuteRefundTest extends TestCase
 
         $result = $client->executeRefund(SidFactory::createFromString('test-sid'));
 
-        self::assertEquals('e40a8e22-016e-4687-870c-f073631e3131', $result->get('transaction_id'));
+        self::assertSame('e40a8e22-016e-4687-870c-f073631e3131', $result->get('transaction_id'));
     }
 
     /**

--- a/tests/SkrillClientExecuteTransferTest.php
+++ b/tests/SkrillClientExecuteTransferTest.php
@@ -59,7 +59,7 @@ class SkrillClientExecuteTransferTest extends TestCase
 
         $result = $client->executeTransfer(SidFactory::createFromString('test-sid'));
 
-        self::assertEquals('2451071245', $result->get('id'));
+        self::assertSame('2451071245', $result->get('id'));
     }
 
     /**

--- a/tests/SkrillClientPrepareOnDemandTest.php
+++ b/tests/SkrillClientPrepareOnDemandTest.php
@@ -72,7 +72,7 @@ class SkrillClientPrepareOnDemandTest extends TestCase
             )
         );
 
-        self::assertEquals('5e281d1376d92ba789ca7f0583e045d4', (string)$sid);
+        self::assertSame('5e281d1376d92ba789ca7f0583e045d4', (string)$sid);
     }
 
     /**

--- a/tests/SkrillClientPreparePayoutTest.php
+++ b/tests/SkrillClientPreparePayoutTest.php
@@ -67,9 +67,9 @@ class SkrillClientPreparePayoutTest extends TestCase
             new Description('subj', 'text')
         );
 
-        $sid = $client->preparePayout($request);
+        $sid = (string)$client->preparePayout($request);
 
-        self::assertEquals('5e281d1376d92ba789ca7f0583e045d4', $sid);
+        self::assertSame('5e281d1376d92ba789ca7f0583e045d4', $sid);
     }
 
     /**

--- a/tests/SkrillClientPrepareRefundTest.php
+++ b/tests/SkrillClientPrepareRefundTest.php
@@ -61,9 +61,9 @@ class SkrillClientPrepareRefundTest extends TestCase
         $client = new Client(['handler' => $this->successRefundMockHandler]);
         $client = new SkrillClient($client, new Email('test@test.com'), new Password('q1234567'));
 
-        $sid = $client->prepareRefund(new RefundRequest(new TransactionID('test')));
+        $sid = (string)$client->prepareRefund(new RefundRequest(new TransactionID('test')));
 
-        self::assertEquals('5e281d1376d92ba789ca7f0583e045d4', $sid);
+        self::assertSame('5e281d1376d92ba789ca7f0583e045d4', $sid);
     }
 
     /**

--- a/tests/SkrillClientPrepareSaleTest.php
+++ b/tests/SkrillClientPrepareSaleTest.php
@@ -107,7 +107,7 @@ class SkrillClientPrepareSaleTest extends TestCase
             )
         );
 
-        self::assertEquals('5e281d1376d92ba789ca7f0583e045d4', (string)$sid);
+        self::assertSame('5e281d1376d92ba789ca7f0583e045d4', (string)$sid);
     }
 
     /**

--- a/tests/SkrillClientPrepareTransferTest.php
+++ b/tests/SkrillClientPrepareTransferTest.php
@@ -69,7 +69,7 @@ class SkrillClientPrepareTransferTest extends TestCase
 
         $sid = $client->prepareTransfer($request);
 
-        self::assertEquals('5e281d1376d92ba789ca7f0583e045d4', $sid);
+        self::assertSame('5e281d1376d92ba789ca7f0583e045d4', (string)$sid);
     }
 
     /**

--- a/tests/SkrillClientViewHistoryTest.php
+++ b/tests/SkrillClientViewHistoryTest.php
@@ -67,9 +67,9 @@ class SkrillClientViewHistoryTest extends TestCase
         /** @var Request $request */
         $request = $container[0]['request'];
         self::assertInstanceOf(Request::class, $request);
-        self::assertEquals('POST', $request->getMethod());
-        self::assertEquals('https://www.skrill.com/app/query.pl', $request->getUri());
-        self::assertEquals(
+        self::assertSame('POST', $request->getMethod());
+        self::assertSame('https://www.skrill.com/app/query.pl', (string)$request->getUri());
+        self::assertSame(
             'email=test%40test.com&password=3ade3fd6e8eef84f2ea91f6474be10d9&action=history&start_date=01-01-2018',
             $request->getBody()->getContents()
         );

--- a/tests/ValueObject/CompanyNameTest.php
+++ b/tests/ValueObject/CompanyNameTest.php
@@ -21,7 +21,7 @@ class CompanyNameTest extends TestCase
         $value = 'test123';
         $authKey = new CompanyName($value);
 
-        self::assertEquals($value, $authKey);
+        self::assertSame($value, (string)$authKey);
     }
 
     /**
@@ -32,7 +32,7 @@ class CompanyNameTest extends TestCase
         $value = str_repeat('a', 30);
         $authKey = new CompanyName($value);
 
-        self::assertEquals($value, $authKey);
+        self::assertSame($value, (string)$authKey);
     }
 
     /**
@@ -42,7 +42,7 @@ class CompanyNameTest extends TestCase
     {
         $authKey = new CompanyName(' test123 ');
 
-        self::assertEquals('test123', $authKey);
+        self::assertSame('test123', (string)$authKey);
     }
 
     /**

--- a/tests/ValueObject/DescriptionTest.php
+++ b/tests/ValueObject/DescriptionTest.php
@@ -21,8 +21,8 @@ class DescriptionTest extends StringValueObjectTestCase
         $text = '4509334';
         $productDescription = new Description($desc, $text);
 
-        self::assertEquals($desc, $productDescription->getSubject());
-        self::assertEquals($text, $productDescription->getText());
+        self::assertSame($desc, $productDescription->getSubject());
+        self::assertSame($text, $productDescription->getText());
     }
 
     /**

--- a/tests/ValueObject/EmailTest.php
+++ b/tests/ValueObject/EmailTest.php
@@ -20,7 +20,7 @@ class EmailTest extends TestCase
     {
         $value = 'test@test.com';
 
-        self::assertEquals($value, new Email($value));
+        self::assertSame($value, (string)(new Email($value)));
     }
 
     /**
@@ -28,7 +28,7 @@ class EmailTest extends TestCase
      */
     public function testSuccess2()
     {
-        self::assertEquals('test@test.com', new Email(' test@test.com '));
+        self::assertSame('test@test.com', (string)(new Email(' test@test.com ')));
     }
 
     /**

--- a/tests/ValueObject/LanguageTest.php
+++ b/tests/ValueObject/LanguageTest.php
@@ -23,7 +23,7 @@ class LanguageTest extends TestCase
      */
     public function testSuccess(string $value)
     {
-        self::assertEquals($value, new Language($value));
+        self::assertSame($value, (string)(new Language($value)));
     }
 
     /**
@@ -31,7 +31,7 @@ class LanguageTest extends TestCase
      */
     public function testSuccess2()
     {
-        self::assertEquals('FR', new Language('FR '));
+        self::assertSame('FR', (string)(new Language('FR ')));
     }
 
     /**

--- a/tests/ValueObject/MerchantIDTest.php
+++ b/tests/ValueObject/MerchantIDTest.php
@@ -14,7 +14,7 @@ class MerchantIDTest extends TestCase
 {
     public function testSuccess()
     {
-        self::assertEquals(111, (new MerchantID(111))->getValue());
-        self::assertEquals(222, (new MerchantID(222))->getValue());
+        self::assertSame(111, (new MerchantID(111))->getValue());
+        self::assertSame(222, (new MerchantID(222))->getValue());
     }
 }

--- a/tests/ValueObject/PasswordTest.php
+++ b/tests/ValueObject/PasswordTest.php
@@ -19,7 +19,7 @@ class PasswordTest extends StringValueObjectTestCase
     {
         $value = 'a1234567';
 
-        self::assertEquals($value, new Password($value));
+        self::assertSame($value, (string)(new Password($value)));
     }
 
     /**
@@ -27,7 +27,7 @@ class PasswordTest extends StringValueObjectTestCase
      */
     public function testSuccess2()
     {
-        self::assertEquals('a1234567', new Password(' a1234567 '));
+        self::assertSame('a1234567', (string)(new Password(' a1234567 ')));
     }
 
     /**

--- a/tests/ValueObject/RecurringBillingNoteTest.php
+++ b/tests/ValueObject/RecurringBillingNoteTest.php
@@ -19,7 +19,7 @@ class RecurringBillingNoteTest extends StringValueObjectTestCase
     {
         $value = 'test123';
 
-        self::assertEquals($value, new RecurringBillingNote($value));
+        self::assertSame($value, (string)(new RecurringBillingNote($value)));
     }
 
     /**
@@ -27,7 +27,7 @@ class RecurringBillingNoteTest extends StringValueObjectTestCase
      */
     public function testSuccess2()
     {
-        self::assertEquals('test123', new RecurringBillingNote(' test123 '));
+        self::assertSame('test123', (string)(new RecurringBillingNote(' test123 ')));
     }
 
     /**

--- a/tests/ValueObject/RecurringPaymentIdTest.php
+++ b/tests/ValueObject/RecurringPaymentIdTest.php
@@ -19,7 +19,7 @@ class RecurringPaymentIdTest extends StringValueObjectTestCase
     {
         $value = 'test123';
 
-        self::assertEquals($value, new RecurringPaymentID($value));
+        self::assertSame($value, (string)(new RecurringPaymentID($value)));
     }
 
     /**
@@ -27,7 +27,7 @@ class RecurringPaymentIdTest extends StringValueObjectTestCase
      */
     public function testSuccess2()
     {
-        self::assertEquals('test123', new RecurringPaymentID(' test123 '));
+        self::assertSame('test123', (string)(new RecurringPaymentID(' test123 ')));
     }
 
     /**

--- a/tests/ValueObject/SecretWordTest.php
+++ b/tests/ValueObject/SecretWordTest.php
@@ -20,7 +20,7 @@ class SecretWordTest extends StringValueObjectTestCase
     {
         $value = 'test123';
 
-        self::assertEquals($value, new SecretWord($value));
+        self::assertSame($value, (string)(new SecretWord($value)));
     }
 
     /**
@@ -28,7 +28,7 @@ class SecretWordTest extends StringValueObjectTestCase
      */
     public function testSuccess2()
     {
-        self::assertEquals('test123', new SecretWord(' test123 '));
+        self::assertSame('test123', (string)(new SecretWord(' test123 ')));
     }
 
     /**

--- a/tests/ValueObject/SidTest.php
+++ b/tests/ValueObject/SidTest.php
@@ -22,7 +22,7 @@ class SidTest extends StringValueObjectTestCase
     {
         $value = 'test123';
 
-        self::assertEquals($value, new Sid($value, new DateTimeImmutable()));
+        self::assertSame($value, (string)(new Sid($value, new DateTimeImmutable())));
     }
 
     /**

--- a/tests/ValueObject/SignatureTest.php
+++ b/tests/ValueObject/SignatureTest.php
@@ -20,7 +20,7 @@ class SignatureTest extends StringValueObjectTestCase
         $value = strtoupper(md5('test123'));
         $signature = new Signature($value);
 
-        self::assertEquals($value, $signature);
+        self::assertSame($value, (string)$signature);
         self::assertTrue($signature->equalToString($value));
         self::assertFalse($signature->equalToString('test'));
     }

--- a/tests/ValueObject/TransactionIDTest.php
+++ b/tests/ValueObject/TransactionIDTest.php
@@ -19,7 +19,7 @@ class TransactionIDTest extends StringValueObjectTestCase
     {
         $value = 'test123';
 
-        self::assertEquals($value, new TransactionID($value));
+        self::assertSame($value, (string)(new TransactionID($value)));
     }
 
     /**
@@ -27,7 +27,7 @@ class TransactionIDTest extends StringValueObjectTestCase
      */
     public function testSuccess2()
     {
-        self::assertEquals('test123', new TransactionID(' test123 '));
+        self::assertSame('test123', (string)(new TransactionID(' test123 ')));
     }
 
     /**

--- a/tests/ValueObject/UrlTest.php
+++ b/tests/ValueObject/UrlTest.php
@@ -34,7 +34,7 @@ class UrlTest extends StringValueObjectTestCase
     {
         $url = 'https://api.com';
 
-        self::assertEquals($url, new Url($url));
+        self::assertSame($url, (string)(new Url($url)));
     }
 
     /**
@@ -42,7 +42,7 @@ class UrlTest extends StringValueObjectTestCase
      */
     public function testSuccess2()
     {
-        self::assertEquals('https://api.com', new Url(' https://api.com '));
+        self::assertSame('https://api.com', (string)(new Url(' https://api.com ')));
     }
 
     /**


### PR DESCRIPTION
# Changed log

- Using the `assertSame` to replace `assertEquals` and it can make assertion equals checking strict.
- Fix namespace for `HistoryItemTest` class and it should be `Skrill\Tests\Response;`.